### PR TITLE
Add Google Analytics tracking to site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 theme: jekyll-theme-cayman
+google_analytics: G-5N4S6R1YXK

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,0 +1,9 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.google_analytics }}');
+</script>


### PR DESCRIPTION
A new file was created (_includes/google-analytics.html) to include the Google Analytics tracking code. The Google Analytics ID is also now configurable through _config.yml.