### PR TITLE
fix: dropdown menu position in user space (legacy version)

### DIFF
--- a/contents/dark-mode.css
+++ b/contents/dark-mode.css
@@ -203,3 +203,8 @@ html.dark-bili:not([lab-style*='dark']):not(.theme-dark):not([data-match-theme='
 .dark-bili:not([lab-style*='dark']):not(.theme-dark):not([data-match-theme='dark']) .pswp img {
   filter: unset;
 }
+
+/* 个人空间：处理.h-inner (https://github.com/flanker/bilibili-dark-mode/issues/28) */
+.dark-bili:not([lab-style*='dark']):not(.theme-dark):not([data-match-theme='dark']) .h-inner {
+  filter: unset;
+}

--- a/contents/dark-mode.ts
+++ b/contents/dark-mode.ts
@@ -74,6 +74,111 @@ const loadDarkMode = () => {
   })
 }
 
+/* User space: Handle .h-inner (https://github.com/flanker/bilibili-dark-mode/issues/28) */
+
+// Constants
+const DEBOUNCE_DELAY = 100;
+const SELECTORS = {
+  H_INNER: '.h-inner',
+  BACKGROUND_LAYER: 'h-inner-background'
+} as const;
+
+// Debounce function
+function debounce<T extends (...args: any[]) => void>(
+  func: T,
+  wait: number
+): (...args: Parameters<T>) => void {
+  let timeout: number;
+  return function executedFunction(...args: Parameters<T>) {
+    const later = () => {
+      clearTimeout(timeout);
+      func(...args);
+    };
+    clearTimeout(timeout);
+    timeout = window.setTimeout(later, wait);
+  };
+}
+
+// Handle user space background image
+function handleProfileBackground(): void {
+  try {
+    const hInner = document.querySelector<HTMLElement>(SELECTORS.H_INNER);
+    if (!hInner) return;
+
+    // Avoid duplicate processing
+    if (hInner.querySelector(`.${SELECTORS.BACKGROUND_LAYER}`)) return;
+
+    // Get background image URL
+    const style = window.getComputedStyle(hInner);
+    const backgroundImage = style.backgroundImage;
+    if (!backgroundImage || backgroundImage === 'none') return;
+
+    // Create background layer
+    const backgroundLayer = document.createElement('div');
+    backgroundLayer.className = SELECTORS.BACKGROUND_LAYER;
+    backgroundLayer.style.cssText = `
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-image: ${backgroundImage};
+      background-size: cover;
+      background-position: center;
+      z-index: -1;
+    `;
+
+    // Clear original background image
+    hInner.style.backgroundImage = 'none';
+
+    // Add background layer
+    hInner.appendChild(backgroundLayer);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error('Error handling user space background:', error.message);
+    } else {
+      console.error('Error handling user space background:', error);
+    }
+  }
+}
+
+// Use debounce for DOM changes
+const debouncedHandleProfileBackground = debounce(handleProfileBackground, DEBOUNCE_DELAY);
+
+// Initialize observer
+function initObserver(): void {
+  // Execute after page load
+  document.addEventListener('DOMContentLoaded', handleProfileBackground);
+
+  // Watch DOM changes for dynamic content loading
+  const observer: MutationObserver = new MutationObserver((mutations: MutationRecord[]) => {
+    for (const mutation of mutations) {
+      if (mutation.addedNodes.length) {
+        debouncedHandleProfileBackground();
+        break;
+      }
+    }
+  });
+
+  // Start observing after DOM is ready
+  if (document.body) {
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+  } else {
+    document.addEventListener('DOMContentLoaded', () => {
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true
+      });
+    });
+  }
+}
+
+// Initialize
+initObserver();
+
 // init dark mode
 loadDarkMode()
 


### PR DESCRIPTION
# Fix dropdown menu position in user space (Legacy Version)

Fixes #28

## Problem
In B站's legacy version, when dark mode is enabled, the dropdown menu position in the user space is incorrect. This is because the `.h-inner` element is inverted, causing the dropdown menu to be flipped as well.

## Solution
Instead of using CSS filters to invert the background image, we now use JavaScript to create a separate background layer. This approach:
1. Creates a new div element with the background image
2. Positions it behind the `.h-inner` element
3. Clears the original background image
4. Ensures the dropdown menu position remains correct

## Technical Details
- Added TypeScript support for better type safety
- Implemented debouncing to optimize performance
- Added error handling for better reliability
- Used MutationObserver to handle dynamic content loading

## Testing
- [x] Dropdown menu position is correct in dark mode
- [x] Background image displays correctly
- [x] No visual artifacts or glitches
- [x] Works with both static and dynamically loaded content
- [x] TypeScript compilation passes
- [x] Error handling works as expected